### PR TITLE
make userhome even less platform-specific

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ class full_install(install):
     user_options = install.user_options + [
         ('userhome=', None,
          "(Linux only) Set user home directory for"
-         " bash completion (/home/{0})"
-         .format(getpass.getuser()))
+         " bash completion ({0})"
+         .format(os.path.expanduser('~')))
     ]
 
     def initialize_options(self):
@@ -56,7 +56,7 @@ class full_install(install):
         if self.userhome:
             self.userhome = '{0}/.bash_completion'.format(self.userhome)
         else:
-            self.userhome = '/home/{0}/.bash_completion'.format(getpass.getuser())
+            self.userhome = '{0}/.bash_completion'.format(os.path.expanduser('~'))
 
         if not os.path.exists(self.userhome) or \
            BASH_COMPLETION not in open(self.userhome, 'r').read():


### PR DESCRIPTION
To install on Ubuntu the setup.py install must be run with sudo. The result was that getpass.getuser() returned 'root' rather than the real username, so the /home/xxx was invalid. This caused the following error...

$ sudo python setup.py install --record installed_files.txt

running install
error: [Errno 2] No such file or directory: '/home/root/.bash_completion'

In contrast, using os.path.expanduser('~') will return the user's home directory across a wide range of platforms

see https://docs.python.org/2/library/os.path.html#os.path.expanduser

NB: I appreciate that there was previous pull request https://github.com/VitaliyRodnenko/geeknote/pull/143 for a more portable way to find username, however the reason for doing that was purely to find the home dir, so this expanduser method is more efficient as well as EVEN more portable :)