### PR TITLE
Preserve 'en-media' tags over edits

### DIFF
--- a/geeknote/editor.py
+++ b/geeknote/editor.py
@@ -121,6 +121,11 @@ class Editor(object):
             for section in soup.findAll('en-todo'):
                 section.replace_with('[ ]')
 
+            # Keep Evernote media elements in html format in markdown so
+            # they'll stay in place over an edit
+            for section in soup.find_all('en-media'):
+                section.replace_with(str(section))
+
 #       content = html2text.html2text(soup.prettify())
 #       content = html2text.html2text(str(soup))
 #       content = html2text.html2text(unicode(soup))


### PR DESCRIPTION
`en-media` tags are used for Evernote images and other media. This
patch will keep the tags as html in the markdown file so they are not erased 
and can even be moved around easily, deleted, duplicated, etc.