### PR TITLE
Date selection in search command

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ That will show you the note "Shopping list 25.04.2012".
 :   Search just in notebook/notebooks you need. The list of notebooks specify by comma.
 
 --date &lt;date or range&gt;
-:   Filter by date. You can set a single date: dd.mm.yyyy, or date range: dd.mm.yyyy-dd.mm.yyyy
+:   Filter by date. You can set a single date in 'yyyy-mm-dd' format or a range with 'yyyy-mm-dd/yyyy-mm-dd'.
 
 --count &lt;how many results to show&gt;
 :   Limits the number of displayed results.
@@ -301,7 +301,7 @@ That will show you the note "Shopping list 25.04.2012".
 
 
 ### Examples
-    $ geeknote find --search "How to patch KDE2" --notebooks "jokes" --date 25.03.2012-25.06.2012
+    $ geeknote find --search "How to patch KDE2" --notebooks "jokes" --date 2015-10-14/2015-10-28
     $ geeknote find --search "apt-get install apache nginx" --content-search --notebooks "manual"
 
 ## Show notes in console

--- a/geeknote/argparser.py
+++ b/geeknote/argparser.py
@@ -168,8 +168,8 @@ COMMANDS_DICT = {
             "--notebooks":  {"altName": "-nb",
                              "help": "In which notebook search the note."},
             "--date":       {"altName": "-d",
-                             "help": "Set date in format dd.mm.yyyy or "
-                                     "date range dd.mm.yyyy-dd.mm.yyyy."},
+                             "help": "Set date in 'yyyy-mm-dd' format or "
+                                     "date range 'yyyy-mm-dd/yyyy-mm-dd' format."},
             "--count":      {"altName": "-cn",
                              "help": "How many notes show in the result list.",
                              "type": int},
@@ -211,8 +211,8 @@ COMMANDS_DICT = {
             "--notebooks":  {"altName": "-nb",
                              "help": "In which notebook search the note."},
             "--date":       {"altName": "-d",
-                             "help": "Set date in format dd.mm.yyyy or "
-                                     "date range dd.mm.yyyy-dd.mm.yyyy."},
+                             "help": "Set date in 'yyyy-mm-dd' format or "
+                                     "date range 'yyyy-mm-dd/yyyy-mm-dd' format."},
             "--count":      {"altName": "-cn",
                              "help": "How many notes show in the result list.",
                              "type": int},

--- a/geeknote/out.py
+++ b/geeknote/out.py
@@ -204,8 +204,9 @@ def showUser(user, fullInfo):
     if fullInfo:
         limit = (int(user.accounting.uploadLimit) / 1024 / 1024)
         endlimit = time.gmtime(user.accounting.uploadLimitEnd / 1000)
-        line('Upload limit', "%.2f" % limit)
+        line('Upload limit', "%.2f MB" % limit)
         line('Upload limit end', time.strftime(config.DEF_DATE_FORMAT, endlimit))
+        line('Timezone ', user.timezone)
 
 
 @preloaderStop


### PR DESCRIPTION
This fixes the date selection in the search command. There is still one caveat, the API doesn't seem to care about the user.timezone attribute, so requests using localtime are handled with GMT-7 or something like that. So I used UTC requests for now based on the system timezone. Which means that if you travel, the search will shift by the timezone difference. The way to go is to always use the default timezone saved in user.timezone. I'll wait for Evernote to reply to this on the forum before trying to revert the timezone difference from the timezone ID.