### PR TITLE
setup is now not stopping when it cannot write autocomplete scripts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import codecs
 import geeknote
 from setuptools import setup
 from setuptools.command.install import install
+import traceback
 
 
 def read(fname):
@@ -37,9 +38,13 @@ class full_install(install):
 
     def install_autocomplete(self):
         def copy_autocomplete(src,dst):
-            if os.path.exists(dst):
-                shutil.copy(src,dst)
-                print('copying %s -> %s' % (src,dst))
+            try:
+                if os.path.exists(dst):
+                    shutil.copy(src,dst)
+                    print('copying %s -> %s' % (src,dst))                
+            except IOError:
+                print('cannot copy autocomplet script %s to %s, got root ?' % (src,dst))
+                print(traceback.format_exc())
 
         print "installing autocomplete"
         copy_autocomplete('completion/bash_completion/_geeknote',self.bash_completion_dir)


### PR DESCRIPTION
On archlinx, some tools (pacaur) reject setup with root rights for security
reason. Thus install fails as autocomplete scripts copy requires root rights
to write in /etc. This patch just catch the exception and print a message
instead of stopping the installation.

This is also the case for launching tox and/or py.test.