### PR TITLE
Fixed homebrew bash completion.

### DIFF
--- a/geeknote.rb
+++ b/geeknote.rb
@@ -8,7 +8,9 @@ class Geeknote < Formula
   def install
     ENV["PYTHONPATH"] = libexec/"vendor/lib/python2.7/site-packages"
     ENV.prepend_create_path "PYTHONPATH", lib+"python2.7/site-packages"
-    system "python", *Language::Python.setup_install_args(prefix), "--bash-completion-dir=#{bash_completion}", "--zsh-completion-dir=#{zsh_completion}"
+    system "python", *Language::Python.setup_install_args(prefix)
+    bash_completion.install "completion/bash_completion/_geeknote" => "geeknote"
+    zsh_completion.install "completion/zsh_completion/_geeknote" => "geeknote"
 
     bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
   end


### PR DESCRIPTION
Bash completion didn't work, at least for me. The command executed had a wrong completion directory. I used the homebrew dedicated commands for bash completion, not setup.py.

>    python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cellar/geeknote/HEAD --single-version-externally-managed --record=installed.txt --bash-completion-dir=/usr/local/Cellar/geeknote/HEAD/etc/bash_completion.d --zsh-completion-dir=/usr/local/Cellar/geeknote/HEAD/share/zsh/site-functions