### PR TITLE
Add pysqlite as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ markdown2
 thrift
 beautifulsoup4
 proxyenv
+pysqlite


### PR DESCRIPTION
This fixes an out of the box post-installation login issue:

```txt
Traceback (most recent call last):
  File "/usr/home/seanc/src/geeknote/bin/geeknote", line 9, in <module>
    load_entry_point('geeknote==2.0.3', 'console_scripts', 'geeknote')()
  File "/usr/home/seanc/src/geeknote/lib/python2.7/site-packages/pkg_resources/__init__.py", line 549, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/home/seanc/src/geeknote/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2709, in load_entry_point
    return ep.load()
  File "/usr/home/seanc/src/geeknote/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2369, in load
    return self.resolve()
  File "/usr/home/seanc/src/geeknote/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2375, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/home/seanc/src/geeknote/lib/python2.7/site-packages/geeknote/geeknote.py", line 24, in <module>
    from editor import Editor, EditorThread
  File "/usr/home/seanc/src/geeknote/lib/python2.7/site-packages/geeknote/editor.py", line 15, in <module>
    from storage import Storage
  File "/usr/home/seanc/src/geeknote/lib/python2.7/site-packages/geeknote/storage.py", line 16, in <module>
    engine = create_engine('sqlite:///' + db_path)
  File "/usr/home/seanc/src/geeknote/lib/python2.7/site-packages/sqlalchemy/engine/__init__.py", line 386, in create_engine
    return strategy.create(*args, **kwargs)
  File "/usr/home/seanc/src/geeknote/lib/python2.7/site-packages/sqlalchemy/engine/strategies.py", line 75, in create
    dbapi = dialect_cls.dbapi(**dbapi_args)
  File "/usr/home/seanc/src/geeknote/lib/python2.7/site-packages/sqlalchemy/dialects/sqlite/pysqlite.py", line 339, in dbapi
    raise e
ImportError: No module named pysqlite2
Exit 1
```