### PR TITLE
Allow for running geeknote without installing

### DIFF
--- a/geeknote/geeknote.py
+++ b/geeknote/geeknote.py
@@ -18,7 +18,7 @@ import evernote.edam.notestore.NoteStore as NoteStore
 from evernote.edam.notestore.ttypes import NotesMetadataResultSpec
 import evernote.edam.type.ttypes as Types
 
-from . import __version__
+from __init__ import __version__
 import config
 import tools
 import out

--- a/geeknote/out.py
+++ b/geeknote/out.py
@@ -8,7 +8,7 @@ import datetime
 import sys
 import os.path
 
-from . import __version__
+from __init__ import __version__
 import tools
 import config
 


### PR DESCRIPTION
If I try to run geeknote directly from the checked out geek repo, I get an error like follows:

>% python2 src/geeknote/geeknote/geeknote.py
>Traceback (most recent call last):
>  File "src/geeknote/geeknote/geeknote.py", line 21, in <module>
>    from . import __version__
>ValueError: Attempted relative import in non-package

This patch turns the relative import into an explicit import of __init__