### PR TITLE
Fix bug in handling of row limit in find command

### DIFF
--- a/geeknote/geeknote.py
+++ b/geeknote/geeknote.py
@@ -253,8 +253,9 @@ class GeekNote(object):
         # notes to come whilst obeying count rules
         while ((result.totalNotes != len(result.notes)) and count != 0):
             offset = len(result.notes)
-            result.notes += self.getNoteStore().findNotesMetadata(self.authToken, noteFilter, offset, count, meta).notes
-            count = max(count - len(result.notes), 0)
+            newresult = self.getNoteStore().findNotesMetadata(self.authToken, noteFilter, offset, count, meta)
+            result.notes += newresult.notes
+            count = max(count - len(newresult.notes), 0)
 
         return result
 


### PR DESCRIPTION
If the find command got too few rows from Evernote and had to try again, it subtracted the total results so far from the count, instead of the results for the current request. This caused the find to terminate too early.

Fixes #77 .