### PR TITLE
Prompt for developer token when login fails

### DIFF
--- a/geeknote/geeknote.py
+++ b/geeknote/geeknote.py
@@ -26,7 +26,7 @@ import out
 from editor import Editor, EditorThread
 from gclient import GUserStore as UserStore
 from argparser import argparser
-from oauth import GeekNoteAuth
+from oauth import GeekNoteAuth, OAuthError
 from storage import Storage
 from log import logging
 
@@ -198,7 +198,21 @@ class GeekNote(object):
 
     def auth(self):
         GNA = GeekNoteAuth()
-        self.authToken = GNA.getToken()
+        try:
+            self.authToken = GNA.getToken()
+        except OAuthError as exc:
+            out.preloader.stop()
+            print exc.message
+
+            import getpass
+            token = getpass.getpass("If you have an Evernote developer token, "
+                                    "enter it here: ")
+            if token:
+                self.authToken = token
+            else:
+                logging.error("No token service and no dev token.")
+                return False
+
         userInfo = self.getUserInfo()
         if not isinstance(userInfo, object):
             logging.error("Could not get user info.")

--- a/geeknote/oauth.py
+++ b/geeknote/oauth.py
@@ -16,6 +16,10 @@ import config
 from log import logging
 
 
+class OAuthError(Exception):
+    '''Generic OAuth exception'''
+
+
 class GeekNoteAuth(object):
 
     consumerKey = config.CONSUMER_KEY
@@ -200,12 +204,12 @@ class GeekNoteAuth(object):
         if response.status != 200:
             logging.error("Unexpected response status on get "
                           "temporary oauth_token 200 != %s", response.status)
-            tools.exitErr()
+            raise OAuthError('OAuth token request failed')
 
         responseData = self.parseResponse(response.data)
         if 'oauth_token' not in responseData:
             logging.error("OAuth temporary not found")
-            tools.exitErr()
+            raise OAuthError('OAuth token request failed')
 
         self.tmpOAuthToken = responseData['oauth_token']
 


### PR DESCRIPTION
This is a reaction to jeffkowalski/geeknote #89. Evernote has revoked
geeknote's API credentials, and for now at least it's necessary for each
user individually to use a personal developer token. It's only necessary
to provide it once, via environment, but that's still somewhat buried.

This update detects when the OAuth temporary token api call fails, and
prompts for a developer token. Once user has entered one, it's retained
in the client settings database and doesn't need to be provided again.