### PR TITLE
Fix unicode encoding errors in gnsync.py

### DIFF
--- a/geeknote/gnsync.py
+++ b/geeknote/gnsync.py
@@ -380,7 +380,7 @@ class GNSync:
                     binaryHash = binascii.unhexlify(imageInfo['hash'])
                     GeekNote(sleepOnRateLimit=self.sleep_on_ratelimit).saveMedia(note.guid, binaryHash, filename)
 
-        content = Editor.ENMLtoText(note.content, self.imageOptions)
+        content = Editor.ENMLtoText(note.content.encode('utf-8'), self.imageOptions)
         path = os.path.join(self.path, escaped_title + self.extension)
         open(path, "w").write(content)
         updated_seconds = note.updated / 1000.0
@@ -461,7 +461,7 @@ class GNSync:
         """
         Get notes from evernote.
         """
-        keywords = 'notebook:"{0}"'.format(tools.strip(self.notebook_name))
+        keywords = 'notebook:"{0}"'.format(tools.strip(self.notebook_name.encode('utf-8')))
         return GeekNote(sleepOnRateLimit=self.sleep_on_ratelimit).findNotes(keywords, EDAM_USER_NOTES_MAX).notes
 
 


### PR DESCRIPTION
Fixes issue #92 by correctly encoding unicode where strings expected in gnsync.py.