### PR TITLE
Changes needed to download notes as markdown with images using gnsync

### DIFF
--- a/geeknote/editor.py
+++ b/geeknote/editor.py
@@ -55,7 +55,7 @@ class Editor(object):
         Creates a list of image resources to save.
         Each has a hash and extension attribute.
         """
-        soup = BeautifulSoup(contentENML.decode("utf-8"), features='lxml')
+        soup = BeautifulSoup(contentENML, features='lxml')
         imageList = []
         for section in soup.findAll("en-media"):
             if "type" in section.attrs and "hash" in section.attrs:

--- a/geeknote/geeknote.py
+++ b/geeknote/geeknote.py
@@ -630,7 +630,7 @@ class GeekNote(object):
         )
         if resource == None:
             return False
-        open(filename, "w").write(resource.data.body)
+        open(filename, "w").write(str(resource.data.body))
         return True
 
 

--- a/geeknote/tools.py
+++ b/geeknote/tools.py
@@ -42,6 +42,9 @@ def strip(data):
     if not data:
         return data
 
+    if isinstance(data, bytes):
+        data = data.decode('utf-8')
+
     if isinstance(data, dict):
         items = iter(data.items())
         return dict([[key.strip(" \t\n\r\"'"), val] for key, val in items])


### PR DESCRIPTION
To succesfully run this command on Manjaro

```
gnsync -f markdown -a --download-only --save-images --images-in-subdir -p .
```

the changes in this PR were needed.

Note: I followed the advice in Issue #136 
Note 2: Can't run tests due to `E   ModuleNotFoundError: No module named 'geeknote'` error, so I don't know if the tests pass :/